### PR TITLE
Clear out @svg after rendering

### DIFF
--- a/ext/mathematical/mathematical.c
+++ b/ext/mathematical/mathematical.c
@@ -150,6 +150,8 @@ static VALUE MATHEMATICAL_process(VALUE self, VALUE rb_LatexCode) {
   rb_hash_aset (result_hash, rb_tainted_str_new2 ("height"), INT2FIX(height_pt));
   rb_hash_aset (result_hash, rb_tainted_str_new2 ("svg"),    rb_iv_get(self, "@svg"));
 
+  rb_iv_set(self, "@svg", Qnil);
+
   return result_hash;
 }
 

--- a/test/mathematical/basic_test.rb
+++ b/test/mathematical/basic_test.rb
@@ -6,4 +6,11 @@ class Mathematical::BasicTest < Test::Unit::TestCase
     assert Mathematical::VERSION
   end
 
+  def test_multiple_calls
+    render = Mathematical::Render.new
+    render.render('$\pi$')
+    output = render.render('$\pi$')['svg']
+    assert_equal 1, output.scan(/<svg/).size, 'should only contain one svg'
+  end
+
 end


### PR DESCRIPTION
There's probably a way to do this without an instance variable, but this fixes the glitch.

/cc @gjtorikian @ptoomey3
