### PR TITLE
Redo strategy around error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,18 @@ Mathematical.new.render(string_with_math)
 The output will be a hash, with keys that depend on the format you want:
 
 * If you asked for an SVG, you'll get:
-  * `width`: the width of the resulting image
-  * `height`: the height of the resulting image
-  * `svg`: the actual string of SVG
+  * `:width`: the width of the resulting image
+  * `:height`: the height of the resulting image
+  * `:data`: the actual string of SVG
 * If you asked for a PNG, you'll get:
-  * `width`: the width of the resulting image
-  * `height`: the height of the resulting image
-  * `png`: the PNG data
+  * `:width`: the width of the resulting image
+  * `:height`: the height of the resulting image
+  * `:data`: the PNG data
 * If you asked for MathML, you'll get:
-  * `mathml`: the MathML data
+  * `:data`: the MathML data
+* If you pass in invalid LaTeX, you'll get:
+  * `:data`: the original invalid LaTeX
+  * `:error`: an error class, and message.
 
 **Note**: If you pass in invalid LaTeX, an error is not raised, but a message *is* printed to STDERR, and the original string is returned (not a hash).
 
@@ -60,10 +63,7 @@ inputs << '$c$'
 Mathematical.new.render(inputs)
 ```
 
-This returns an array of hashes, possessing the same keys as above.
-
-**Note**: With an array, it is possible to receive elements that are not hashes. For example, given the following input:
-
+This returns an array of hashes, possessing the same keys as above. For example:
 ```
 array = ['$foof$', '$not__thisisnotreal$', '$poof$']
 ```
@@ -72,10 +72,10 @@ You will receive the following output:
 
 ```
 Mathematical.new.render(array)
-[ {:svg => "...", :width => ... }, '$not__thisisnotreal$', {:svg => "...", :width => ... }]
+[ {:data => "...", :width => ... }, { :data => '$not__thisisnotreal$', :error => "...", {:data => "...", :width => ... }]
 ```
 
-That is, while the first and last elements are valid LaTeX math, the middle one is not, so the same string is returned. As with a single string, a message is also printed to STDERR.
+That is, while the first and last elements are valid LaTeX math, the middle one is not, so the same string is returned. As with single strings, a message is also printed to STDERR.
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The output will be a hash, with keys that depend on the format you want:
   * `:data`: the MathML data
 * If you pass in invalid LaTeX, you'll get:
   * `:data`: the original invalid LaTeX
-  * `:error`: an error class, and message.
+  * `:error`: the error class (with message)
 
 **Note**: If you pass in invalid LaTeX, an error is not raised, but a message *is* printed to STDERR, and the original string is returned (not a hash).
 

--- a/ext/mathematical/mathematical.c
+++ b/ext/mathematical/mathematical.c
@@ -248,7 +248,6 @@ static VALUE MATHEMATICAL_process(VALUE self, VALUE rb_Input)
       args[3] = ULONG2NUM(latex_size);
       hash = rb_rescue(process_helper, args, process_rescue, math);
 
-      // the call errored; just store the same string
       rb_ary_store(output, i, hash);
     }
     break;

--- a/lib/mathematical.rb
+++ b/lib/mathematical.rb
@@ -34,13 +34,13 @@ class Mathematical
     maths = validate_content(maths)
 
     begin
-      data = @processer.process(maths)
-      fail RuntimeError if data.nil? || (!data.is_a?(Hash) && !data.is_a?(Array))
+      result_data = @processer.process(maths)
+      fail RuntimeError if result_data.nil? || (!result_data.is_a?(Hash) && !result_data.is_a?(Array))
 
-      if data.is_a? Array
-        data.map { |d| format_data(d) }
+      if result_data.is_a? Array
+        result_data.map { |d| format_data(d) }
       else
-        format_data(data)
+        format_data(result_data)
       end
     rescue ParseError, DocumentCreationError, DocumentReadError => e
       # an error in the C code, probably a bad TeX parse
@@ -96,19 +96,19 @@ class Mathematical
     maths =~ /\A\${1,2}/
   end
 
-  def format_data(data)
+  def format_data(result_hash)
     # we passed in an array of math, and found an unprocessable element
-    return data unless data.is_a? Hash
+    return result_hash if result_hash[:exception]
 
     case @config[:format]
     when :svg
       # remove starting <?xml...> tag
-      data['svg'] = data['svg'][XML_HEADER.length..-1]
-      data['svg'] = svg_to_base64(data['svg']) if @config[:base64]
+      result_hash[:data] = result_hash[:data][XML_HEADER.length..-1]
+      result_hash[:data] = svg_to_base64(result_hash[:data]) if @config[:base64]
 
-      data
+      result_hash
     when :png, :mathml # do nothing with these...for now?
-      data
+      result_hash
     end
   end
 

--- a/test/mathematical/basic_test.rb
+++ b/test/mathematical/basic_test.rb
@@ -9,7 +9,7 @@ class Mathematical::BasicTest < Test::Unit::TestCase
   def test_multiple_calls
     render = Mathematical.new
     render.render('$\pi$')
-    output = render.render('$\pi$')['svg']
+    output = render.render('$\pi$')[:data]
     assert_equal 1, output.scan(/<svg/).size, 'should only contain one svg'
   end
 

--- a/test/mathematical/fixtures_test.rb
+++ b/test/mathematical/fixtures_test.rb
@@ -18,14 +18,14 @@ class Mathematical::FixturesTest < Test::Unit::TestCase
           svg_content = Mathematical.new(:base64 => false).render(eq)
           # remove \ and $, remove whitespace, keep alphanums, remove extraneous - and trailing -
           filename = eq.gsub(/[\$\\]*/, '').gsub(/\s+/, '-').gsub(/[^a-zA-Z\d]/, '-').gsub(/-{2,}/, '-').gsub(/-$/, '')
-          File.open("samples/fixtures/#{filename}.svg", 'w') { |file| file.write svg_content['svg'] }
+          File.open("samples/fixtures/#{filename}.svg", 'w') { |file| file.write svg_content[:data] }
         end
       end
 
       actual = MathToItex(source).convert do |eq, type|
         svg_content = Mathematical.new(:base64 => true).render(eq)
 
-        %|<img class="#{type.to_s}-math" data-math-type="#{type.to_s}-math" src="#{svg_content['svg']}"/>|
+        %(<img class="#{type}-math" data-math-type="#{type}-math" src="#{svg_content[:data]}"/>)
       end.rstrip
 
       expected_file = before.sub(/before/, 'after').sub(/text/, 'html')
@@ -34,7 +34,7 @@ class Mathematical::FixturesTest < Test::Unit::TestCase
 
       expected = File.read(expected_file)
 
-      expected = (MathToItex(expected).convert {|string| Mathematical.new.render(string)}).rstrip
+      expected = (MathToItex(expected).convert { |string| Mathematical.new.render(string) }).rstrip
 
       # Travis and OS X each render SVGs differently. For now, let's just be happy
       # that something renders at all.

--- a/test/mathematical/maliciousness_test.rb
+++ b/test/mathematical/maliciousness_test.rb
@@ -109,8 +109,30 @@ class Mathematical::MaliciousnessTest < Test::Unit::TestCase
     assert_equal 3, output.length
     assert_equal Hash, output.first.class
     assert_equal Hash, output.last.class
-    assert_equal '$/this___istotallyfake$', output[1]
-    # array errors output to STDERR
-    assert_match /Failed to parse mtex: \$\/this___istotallyfake\$/, err
+
+    assert_equal '$/this___istotallyfake$', output[1][:data]
+    assert_equal Mathematical::ParseError, output[1][:exception].class
+    assert_match 'Failed to parse mtex', output[1][:exception].message
+
+    # array errors also output to STDERR
+    assert_match /Failed to parse mtex/, err
+  end
+
+  def test_it_passes_a_legible_error_for_maxsize
+    output = nil
+    render = Mathematical.new({:maxsize => 2})
+
+    _, err = capture_subprocess_io do
+      output = render.render(['$a \ne b$'])
+    end
+
+    assert_equal 1, output.length
+
+    assert_equal '$a \ne b$', output[0][:data]
+    assert_equal Mathematical::MaxsizeError, output[0][:exception].class
+    assert_match 'Size of latex string is greater than the maxsize', output[0][:exception].message
+
+    # array errors also output to STDERR
+    assert_match /Size of latex string is greater than the maxsize/, err
   end
 end

--- a/test/mathematical/mathjax_test.rb
+++ b/test/mathematical/mathjax_test.rb
@@ -16,7 +16,7 @@ class Mathematical::MathJaxTest < Test::Unit::TestCase
       assert_nothing_raised { data = render_svg.render(tex_contents) }
 
       # assert the SVG actually rendered
-      doc = Nokogiri::HTML(data['svg'])
+      doc = Nokogiri::HTML(data[:data])
       assert_empty doc.search(%(//svg[@width='0pt']))
       assert_empty doc.search(%(//svg[@height='0pt']))
     end

--- a/test/mathematical/mathml_test.rb
+++ b/test/mathematical/mathml_test.rb
@@ -14,7 +14,7 @@ class Mathematical::MathMLTest < Test::Unit::TestCase
 $$
 '''
     render = Mathematical.new({:format => :mathml})
-    mathml = render.render(string)['mathml']
+    mathml = render.render(string)[:data]
 
     assert_match %r{<math xmlns='http://www.w3.org/1998/Math/MathML' display='block'><semantics><mrow><mrow><mo>\(}, mathml
   end

--- a/test/mathematical/multiples_test.rb
+++ b/test/mathematical/multiples_test.rb
@@ -16,7 +16,7 @@ $$
 '''
 
     output = @render.render([string])
-    svg = output.first['svg']
+    svg = output.first[:data]
 
     assert_equal 1, svg.scan(/svg\+xml;/).size, 'should only contain one svg'
     assert_match 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My', svg
@@ -38,13 +38,13 @@ $$
     output = @render.render(inputs)
     assert_equal 1000, output.length
     output.each do |data|
-      assert_match 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My', data['svg']
+      assert_match 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My', data[:data]
     end
   end
 
   def test_it_properly_accounts_for_equations
     inputs = []
-    [1, 2].each do |i|
+    (1..2).each do |i|
       string = """
   $$
   \\begin{equation}
@@ -60,8 +60,8 @@ $$
     output = render.render(inputs)
     assert_equal 3, output.length
     output.each_with_index do |data_hash, i|
-      header = data_hash['png'].unpack('H*').first.slice(0, 18)
-      File.open("#{fixtures_dir}/png/numeric_test_#{i + 1}.png", 'w') { |f| f.write(data_hash['png'])}
+      header = data_hash[:data].unpack('H*').first.slice(0, 18)
+      File.open("#{fixtures_dir}/png/numeric_test_#{i + 1}.png", 'w') { |f| f.write(data_hash[:data])}
       assert_equal header, '89504e470d0a1a0a00'
     end
   end

--- a/test/mathematical/png_test.rb
+++ b/test/mathematical/png_test.rb
@@ -18,8 +18,8 @@ $$
 '''
     render = Mathematical.new({:format => :png})
     data_hash = render.render(string)
-    header = data_hash['png'].unpack('H*').first.slice(0, 18)
-    File.open("#{fixtures_dir}/png/pmatrix.png", 'w') { |f| f.write(data_hash['png'])}
+    header = data_hash[:data].unpack('H*').first.slice(0, 18)
+    File.open("#{fixtures_dir}/png/pmatrix.png", 'w') { |f| f.write(data_hash[:data])}
     assert_equal header, '89504e470d0a1a0a00'
   end
 end


### PR DESCRIPTION
* Hash returns now use symbols, not strings
* Every hash returns the same key, `:data`
* If a hash is actually an error, it returns `exception`, containing the error class (with message)