### PR TITLE
Fix bootstrap script on Linux

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -16,5 +16,5 @@ echo "==> Installing required libraries…"
 if [ "$(uname)" == "Darwin" ]; then
   ../script/install_homebrew_deps
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  ../script/install_linux_deps
+  $(dirname $0)/install_linux_deps
 fi

--- a/script/install_linux_deps
+++ b/script/install_linux_deps
@@ -7,5 +7,5 @@ sudo apt-get -qq -y install bison flex libffi-dev libxml2-dev libgdk-pixbuf2.0-d
 
 # not necessary for tests, but is for any production/development environment
 if [[ ! -v CI ]]; then
-  sudo apt-get -qq -y install ttf-lyx
+  sudo apt-get -qq -y install fonts-lyx
 fi


### PR DESCRIPTION
If I clone this repo and run `script/bootstrap` on Linux, then it errors with:
```
==> Installing required libraries…
script/bootstrap: line 19: ../script/install_linux_deps: No such file or directory
```
so I fixed that.
And then (after asking me for my password) it errored with:
```
==> Installing required libraries…
[sudo] password for andrew: 
E: Package 'ttf-lyx' has no installation candidate
```
so I fixed that too :slightly_smiling_face: 