### PR TITLE
Update mtex2MML to 43f9e36f4b01013100f86073ac70d1855b3cc4cb

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,8 @@ name: Linting
 
 on:
   pull_request:
-    paths:
-      - "**/*.rb"
+    branches:
+      - main
 
 permissions:
   contents: read


### PR DESCRIPTION
This fixes a build failure to do with the strict prototype warning, which 
was fixed in mtex2ml in https://github.com/gjtorikian/mtex2MML/pull/75. 
Fixes #119
