### PR TITLE
Update Lasem

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,8 @@
 [submodule "ext/mathematical/lasem"]
   path = ext/mathematical/lasem
-  url = https://gitlab.gnome.org/GNOME/lasem.git
+	url = https://github.com/LasemProject/lasem.git
   ignore = dirty
+	branch = main
 [submodule "ext/mathematical/mtex2MML"]
 	path = ext/mathematical/mtex2MML
 	url = https://github.com/gjtorikian/mtex2MML

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ no intermediate binaries. It was, unfortunately, a bit slow: for an arbitrary
 composition of 880 equations, it took about eight seconds to complete. Could I
 do better?
 
-* I came across [Lasem](https://wiki.gnome.org/action/show/Projects/Lasem?action=show&redirect=Lasem),
+* I came across [Lasem](https://github.com/LasemProject/lasem),
 which met every need. It has no external binary dependencies (only library packages),
 can convert directly to SVG, and it's fast. The same arbitrary 880 equations were
 rendered in moments.


### PR DESCRIPTION
This updates Lasem to use the new mantained repository, instead of the abandoned gnome repository.