### PR TITLE
Added Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ _yardoc
 *.gif
 *.rbc
 *.so
+*.dll
 .byebug_history
 /vendor/cache/ruby/
 /vendor/gems/

--- a/README-Windows.md
+++ b/README-Windows.md
@@ -1,0 +1,20 @@
+## How to build on Windows
+
+1. Install Ruby with RIDK
+2. Start Powershell as Administrator and run the following commands:
+    1. `ridk enable`
+    2. `pacman -S mingw-w64-ucrt-x86_64-cmake bison flex python`
+    3. `pacman -S mingw-w64-ucrt-x86_64-libxml2 libxml2-devel`
+    4. `pacman -S mingw-w64-ucrt-x86_64-glib2 glib2-devel`
+    5. `pacman -S mingw-w64-ucrt-x86_64-cairo mingw-w64-ucrt-x86_64-pango mingw-w64-ucrt-x86_64-gdk-pixbuf2`
+3. Start Powershell as a non-privileged user and run the following commands:
+    1. `ridk enable`
+    2. `git submodule update --init --recursive`
+    3. `bundle install`
+    4. `rake compile`
+4. Copy **liblasem.dll** to somewhere in the system $PATH
+5. The package can be tested by running `rake test` now in the non-privileged shell
+
+NOTE: Installing the plain **cmake** package with pacman will result in build errors when building
+this package. That version of CMake doesn't understand Windows paths and will prepend the current 
+build directory to the CFLAGs include directories.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Check out [SUPPORTED.md on the mtex2MML website](https://github.com/gjtorikian/m
 
 ## Building
 
+_If building on Windows, see this [README](README-Windows.md)._
+
 Before building this gem, you must install the following libraries:
 
 * Ruby 2.1 or higher (you'll need Ruby header files, so a `*-dev` version is also required)

--- a/ext/mathematical/CMakeLists.txt
+++ b/ext/mathematical/CMakeLists.txt
@@ -17,7 +17,6 @@ find_package(PkgConfig REQUIRED)
 set(LASEM_SRC_DIR ${CMAKE_SOURCE_DIR}/lasem/src/)
 set(MTEX2MML_SRC_DIR ${CMAKE_SOURCE_DIR}/mtex2MML/src/)
 set(MTEX2MML_BUILD_DIR ${CMAKE_SOURCE_DIR}/mtex2MML/build/)
-set(INCLUDE_DIRS ${INCLUDE_DIRS} ${RUBY_INCLUDE_PATH} ${MTEX2MML_SRC_DIR} ${LASEM_SRC_DIR})
 
 file(GLOB_RECURSE LASEM_SRC ${LASEM_SRC_DIR}/*.c)
 file(GLOB_RECURSE LASEM_HEADERS ${LASEM_SRC_DIR}/*.h)
@@ -39,12 +38,12 @@ add_library(${LIBRARY} SHARED
 #
 #
 pkg_check_modules(GLIB2 REQUIRED glib-2.0)
+pkg_check_modules(GIO2 REQUIRED gio-2.0)
 pkg_check_modules(CAIRO REQUIRED cairo)
 pkg_check_modules(PANGO REQUIRED pango)
-pkg_check_modules(GDK-PIXBUF2 REQUIRED gdk-pixbuf-2.0)
-pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
-pkg_check_modules(GIO2 REQUIRED gio-2.0)
 pkg_check_modules(PANGO_CAIRO REQUIRED pangocairo)
+pkg_check_modules(GDK_PIXBUF2 REQUIRED gdk-pixbuf-2.0)
+pkg_check_modules(LIBXML2 REQUIRED libxml-2.0)
 
 #
 #
@@ -70,48 +69,31 @@ set(GLIB_LIB_SUFFIX 2.0)
 set(PANGO_LIB_SUFFIX 1.0)
 set(GDK_PIXBUF_LIB_SUFFIX 2.0)
 
-# find dependencies
-# glib
-find_path(GLIB_INCLUDE_DIR glib.h)
-find_library(GLIB_GLIB_LIBRARY glib-${GLIB_LIB_SUFFIX})
-find_library(GLIB_GIO_LIBRARY gio-${GLIB_LIB_SUFFIX})
-find_library(GLIB_GMODULE_LIBRARY gmodule-${GLIB_LIB_SUFFIX})
-find_library(GLIB_GOBJECT_LIBRARY gobject-${GLIB_LIB_SUFFIX})
-set(GLIB_LIBRARIES ${GLIB_GLIB_LIBRARY} ${GLIB_GIO_LIBRARY} ${GLIB_GMODULE_LIBRARY} ${GLIB_GOBJECT_LIBRARY})
 
-# pango
-find_path(PANGO_INCLUDE_DIR pango/pango.h)
-find_library(PANGO_LIBRARY pango-${PANGO_LIB_SUFFIX})
-find_library(PANGO_CAIRO_LIBRARY pangocairo-${PANGO_LIB_SUFFIX})
-set(PANGO_LIBRARIES ${PANGO_LIBRARY} ${PANGO_CAIRO_LIBRARY})
+target_include_directories(${LIBRARY} PRIVATE
+  ${MTEX2MML_SRC_DIR} 
+  ${LASEM_SRC_DIR}
+)
 
-# cairo
-find_library(CAIRO_LIBRARY cairo${CAIRO_LIB_SUFFIX})
-find_library(CAIRO_GOBJECT_LIBRARY cairo-gobject${CAIRO_LIB_SUFFIX})
-set(CAIRO_LIBRARIES ${CAIRO_LIBRARY} ${CAIRO_GOBJECT_LIBRARY})
-find_path(CAIRO_INCLUDE_DIR cairo.h)
-
-# gdk-pixbuf
-find_path(GDK_PIXBUF_INCLUDE_DIR gdk-pixbuf/gdk-pixbuf.h)
-find_library(GDK_PIXBUF_LIBRARY gdk_pixbuf-${GDK_PIXBUF_LIB_SUFFIX})
-
-include_directories(${LIBRARY}
-  ${INCLUDE_DIRS}
+target_include_directories(${LIBRARY} PUBLIC
+  ${RUBY_INCLUDE_PATH} 
   ${GLIB2_INCLUDE_DIRS}
+  ${GIO2_INCLUDE_DIRS}
   ${CAIRO_INCLUDE_DIRS}
-  ${GDK-PIXBUF2_INCLUDE_DIRS}
+  ${PANGO_CAIRO_INCLUDE_DIRS}
+  ${GDK_PIXBUF2_INCLUDE_DIRS}
   ${LIBXML2_INCLUDE_DIRS}
   ${LIBXML2_MACOS_INCLUDE_DIRS}
-  ${GIO2_INCLUDE_DIRS}
-  ${PANGO_CAIRO_INCLUDE_DIRS}
 )
 
 target_link_libraries(${LIBRARY}
-  ${GLIB_LIBRARIES}
+  ${RUBY_LIBRARY}
+  ${GLIB2_LIBRARIES}
+  ${GIO2_LIBRARIES}
   ${CAIRO_LIBRARIES}
   ${PANGO_LIBRARIES}
-  ${GDK_PIXBUF_LIBRARY}
+  ${PANGO_CAIRO_LIBRARIES}
+  ${GDK_PIXBUF2_LIBRARIES}
   ${LIBXML2_LIBRARIES}
-  ${RUBY_LIBRARY}
   ${MTEX2MML_BUILD_DIR}/libmtex2MML.a
 )

--- a/ext/mathematical/CMakeLists.txt
+++ b/ext/mathematical/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 project(lasem)
 enable_language(C)
-cmake_minimum_required(VERSION 2.8.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 cmake_policy(SET CMP0015 NEW)
 set(CMAKE_MACOSX_RPATH 1)
 

--- a/ext/mathematical/extconf.rb
+++ b/ext/mathematical/extconf.rb
@@ -22,7 +22,7 @@ end
 
 LIBDIR     = RbConfig::CONFIG["libdir"]
 INCLUDEDIR = RbConfig::CONFIG["includedir"]
-SHARED_EXT = OS == :macos ? "dylib" : "so"
+SHARED_EXT = OS == :macos ? "dylib" : OS == :windows ? "dll" : "so"
 # Starting in Catalina, libxml2 was moved elsewhere
 SDKROOT = OS == :macos ? %x(/usr/bin/xcrun --show-sdk-path).chomp : ""
 RPATH = OS == :macos ? "-rpath @loader_path/../../ext/mathematical/lib".chomp : ""

--- a/ext/mathematical/extconf.rb
+++ b/ext/mathematical/extconf.rb
@@ -26,6 +26,7 @@ SHARED_EXT = OS == :macos ? "dylib" : "so"
 # Starting in Catalina, libxml2 was moved elsewhere
 SDKROOT = OS == :macos ? %x(/usr/bin/xcrun --show-sdk-path).chomp : ""
 RPATH = OS == :macos ? "-rpath @loader_path/../../ext/mathematical/lib".chomp : ""
+CMAKE_GENERATOR = OS == :windows ? "-G \"MSYS Makefiles\"" : ""
 
 unless find_executable("cmake")
   $stderr.puts "\n\n\n[ERROR]: cmake is required and not installed. Get it here: http://www.cmake.org/\n\n"
@@ -77,7 +78,7 @@ clean_dir(LASEM_BUILD_DIR)
 if !using_system_mtex2mml?
   # build mtex2MML library
   Dir.chdir(MTEX2MML_BUILD_DIR) do
-    system "cmake .."
+    system "cmake #{CMAKE_GENERATOR} .."
     system "make libmtex2MML_static"
   end
   FileUtils.mkdir_p(MTEX2MML_LIB_DIR)
@@ -94,7 +95,7 @@ if !using_system_lasem?
   # build Lasem library
   # SHOULD BE DYNAMICALLY LINKED for potential LGPL copyright issues
   Dir.chdir(LASEM_BUILD_DIR) do
-    system "cmake ../.."
+    system "cmake #{CMAKE_GENERATOR} ../.."
     system "make"
   end
   FileUtils.mkdir_p(LASEM_LIB_DIR)


### PR DESCRIPTION
This pull request adds Windows build support. I have ran the unit tests and also looked at the PNG and SVG output for some of my own LaTeX documents. All the unit tests passed except for a couple that are being skipped. The tests also pass on an Ubuntu install that I tried them on.

I updated the mtex2MML submodule because the commit that was checked out had an older CMakeLists.txt build script that didn't have a supported minimum CMake required version.